### PR TITLE
Update to build using XCode 11.4.1

### DIFF
--- a/.buildkite/pipeline.rb
+++ b/.buildkite/pipeline.rb
@@ -24,7 +24,7 @@ pipeline['steps'] << {
   'label' => ':swift: iOS tests',
   'command' => '.buildkite/ios-pipeline-command.sh',
   'timeout_in_minutes' => 120,
-  'agents' => { 'queue' => 'ios-13' },
+  'agents' => { 'queue' => 'ios-xcode-11-14-1' },
   'plugins' => secrets_plugin,
   'env' => {
     'DOCKER_PULL_ROOT_SERVER' => 'false'
@@ -35,7 +35,7 @@ pipeline['steps'] << {
   'label' => ':swift: Swift Format',
   'command' => '.buildkite/ios-pipeline-command-swiftformat.sh',
   'timeout_in_minutes' => 120,
-  'agents' => { 'queue' => 'ios-13' },
+  'agents' => { 'queue' => 'ios-xcode-11-14-1' },
   'plugins' => secrets_plugin,
   'env' => {
     'DOCKER_PULL_ROOT_SERVER' => 'false'


### PR DESCRIPTION
We deprecated `ios-13` queue on Mac Stadium. Bumping the build agent to use Mac Stadium with XCode 11.4.1